### PR TITLE
Cleaned code making it more idiomatic

### DIFF
--- a/libvfio.nimble
+++ b/libvfio.nimble
@@ -12,7 +12,7 @@ bin           = @["arcd"]
 # Dependencies
 
 requires "nim >= 1.4.8",
-    "yaml",
-    "uuids",
-    "psutil",
-    "terminaltables"
+    "yaml >= 0.16.0",
+    "uuids >= 0.1.11",
+    "psutil >= 0.6.0",
+    "terminaltables >= 0.1.1"

--- a/src/arcd.nim
+++ b/src/arcd.nim
@@ -2,8 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Main file for running the arcd process
 #
-import options
-import os
+import std/[options, os]
 
 import libvfio/[control, logger, types, comms]
 

--- a/src/libvfio/comms/ls.nim
+++ b/src/libvfio/comms/ls.nim
@@ -2,10 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Provide functions for ls
 #
-import os
-import strformat
-import strutils
-import options
+import std/[os, strformat, strutils, options]
 
 import ../types
 

--- a/src/libvfio/comms/ps.nim
+++ b/src/libvfio/comms/ps.nim
@@ -34,11 +34,11 @@ type
     path: string        ## Lock path
 
 
-func newData(wl: wLock): LockData =
+func newData(wl: WLock): LockData =
   ## newData - Creates an object based on the lock
   ## 
   ## Inputs
-  ## @wl - wLock wrapped form of lock
+  ## @wl - WLock wrapped form of lock
   ## 
   ## Returns
   ## result - LockData object
@@ -73,11 +73,11 @@ func newTable(headers: seq[Cell]): TerminalTable =
   result.style = asciiStyle
   result.separateRows = false
 
-func overviewPs(locks: seq[wLock]): string =
+func overviewPs(locks: seq[WLock]): string =
   ## createPsTable - Creates a table for arc ps
   ## 
   ## Inputs
-  ## @locks - sequence of wLock
+  ## @locks - sequence of WLock
   ## 
   ## Returns
   ## result - string which contains the table
@@ -133,9 +133,9 @@ proc createTableStates(d: LockData): string =
   ## Returns
   ## result - string containg table
   let headers = @[
-    newCell("State", pad=1),
-    newCell("Location", pad=1),
-    newCell("Size (MiB)", pad=1)
+    newCell("State", pad = 1),
+    newCell("Location", pad = 1),
+    newCell("Size (MiB)", pad = 1)
   ]
   var tt = newTable(headers)
 
@@ -156,10 +156,10 @@ func createTableGpus(d: LockData): string =
   ## Returns
   ## result - string containing table
   let headers = @[
-    newCell("Device Name", pad=1),
-    newCell("VRAM", pad=1),
-    newCell("Type", pad=1),
-    newCell("Virtual Map", pad=1)
+    newCell("Device Name", pad = 1),
+    newCell("VRAM", pad = 1),
+    newCell("Type", pad = 1),
+    newCell("Virtual Map", pad = 1)
   ]
   var tt = newTable(headers)
 
@@ -177,8 +177,8 @@ func createTableNets(d: LockData): string =
   ## Returns
   ## result - string containing table
   let headers = @[
-    newCell("Device Name", pad=1),
-    newCell("MAC", pad=1)
+    newCell("Device Name", pad = 1),
+    newCell("MAC", pad = 1)
   ]
   var tt = newTable(headers)
 
@@ -198,8 +198,8 @@ func createTablePorts(d: LockData): string =
   func generateHeaders(n: int): seq[Cell] =
     for i in 1 .. n:
       result &= @[
-        newCell("Guest", pad=1),
-        newCell("Host", pad=1)
+        newCell("Guest", pad = 1),
+        newCell("Host", pad = 1)
       ]
 
   let headers = generateHeaders(1)
@@ -256,7 +256,7 @@ proc arcPs*(cfg: Config, cmd: CommandLineArguments) =
       echo textNoActiveSessions
     else:
       echo overviewPs(locks)
-  proc psA(cfg: Config, locks: seq[wLock]) =
+  proc psA(cfg: Config, locks: seq[WLock]) =
     if len(locks) == 0:
       echo textNoActiveSessions
     elif len(locks) == 1:

--- a/src/libvfio/comms/qmp.nim
+++ b/src/libvfio/comms/qmp.nim
@@ -2,14 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Code to interact with QMP for different commands.
 #
-import asyncnet
-import asyncdispatch
-import os
-import options
-import nativesockets
-import json
-import logging
-import strutils
+import std/[asyncnet, asyncdispatch, os, options, nativesockets, json, logging, strutils]
 
 import ../types
 

--- a/src/libvfio/control/arguments.nim
+++ b/src/libvfio/control/arguments.nim
@@ -2,12 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Creates commands to execute on the host system.
 #
-import strformat
-import strutils
-import sequtils
-import sugar
-import options
-import os
+import std/[strformat, strutils, sequtils, sugar, options, os]
 
 import ../types
 
@@ -186,6 +181,8 @@ func qemuLaunch*(cfg: Config, uuid: string,
 
   let
     qemuLogFile = logDir / (uuid & "-session.txt")
+  
+  result.args = newSeqOfCap[string](128) # With all seqs this has to be a tinge nice to the ol' allocator
 
   # executing target
   result.exec = "/bin/qemu-system-x86_64"

--- a/src/libvfio/control/introspection.nim
+++ b/src/libvfio/control/introspection.nim
@@ -2,11 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Introspection specific code.
 #
-import os
-import osproc
-import posix
-import strformat
-import logging
+import std/[os, osproc, posix, strformat, logging]
 
 import ../types
 

--- a/src/libvfio/control/iommu.nim
+++ b/src/libvfio/control/iommu.nim
@@ -2,17 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Algorithms for IOMMU handling.
 #
-import algorithm
-import math
-import sequtils
-import strutils
-import parseutils
-import strformat
-import sugar
-import options
-import os
-import tables
-import logging
+import std/[algorithm, math, sequtils, strutils, parseutils, strformat, sugar, options, os, tables, logging]
 
 import arguments
 
@@ -170,7 +160,7 @@ proc getVfios*(cfg: Config, uuid: string): seq[Vfio] =
       deviceClass = fromHex[int](readFile(deviceClassFile)[0 .. 3])
 
     # If we do not support this device type, we do not pass it through.
-    if not deviceClass in PassableVfios:
+    if deviceClass notin PassableVfios:
       continue
 
     let

--- a/src/libvfio/control/vm.nim
+++ b/src/libvfio/control/vm.nim
@@ -2,16 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Code to interact with VMs.
 #
-import asyncnet
-import asyncdispatch
-import os
-import osproc
-import posix
-import options
-import strformat
-import sequtils
-import sugar
-import logging
+import std/[asyncnet, asyncdispatch, os, osproc, posix, options, strformat, sequtils, sugar, logging]
 
 import arguments
 import introspection
@@ -197,21 +188,21 @@ proc startVm*(c: Config, uuid: string, newInstall: bool,
   # At this point we are in the child process
   let
     qemuArgs = qemuLaunch(
-      cfg=cfg,
-      uuid=uuid,
-      vfios=lock.vfios,
-      mdevs=lock.mdevs,
-      kernel=liveKernel,
-      install=newInstall,
-      logDir=qemuLogs,
-      sockets=sockets
+      cfg = cfg,
+      uuid = uuid,
+      vfios = lock.vfios,
+      mdevs = lock.mdevs,
+      kernel = liveKernel,
+      install = newInstall,
+      logDir = qemuLogs,
+      sockets = sockets
     )
 
   var
     qemuPid = startProcess(
       qemuArgs.exec,
-      args=qemuArgs.args,
-      options={poEchoCmd, poParentStreams}
+      args = qemuArgs.args,
+      options = {poEchoCmd, poParentStreams}
     )
 
   lock.pidNum = processID(qemuPid)

--- a/src/libvfio/logger.nim
+++ b/src/libvfio/logger.nim
@@ -2,7 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Sets up logging on the system.
 #
-import logging
+import std/logging
 
 # Allows us to export the logging to prevent a secondary logging import
 export logging

--- a/src/libvfio/types/config.nim
+++ b/src/libvfio/types/config.nim
@@ -2,12 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Configuration specific parameters/loaders
 #
-import parseopt
-import options
-import os
-import streams
-import strutils
-import logging
+import std/[parseopt, options, os, streams, strutils, logging]
 import yaml
 
 import connectivity, hardware, environment, process
@@ -133,24 +128,10 @@ proc getCommandLine*(): CommandLineArguments =
   ##
   ## Side effects - Reads the command line arguments.
   func getCommand(key: string): Option[CommandEnum] =
-    case toLowerAscii(key)
-    of $ceIntrospect:
-      some(ceIntrospect)
-    of $ceCreate:
-      some(ceCreate)
-    of $ceStart:
-      some(ceStart)
-    of $ceStop:
-      some(ceStop)
-    of $ceLs:
-      some(ceLs)
-    of $cePs:
-      some(cePs)
-    of $ceDeploy:
-      some(ceDeploy)
-    of $ceUndeploy:
-      some(ceUndeploy)
-    else: none(CommandEnum)
+    try:
+      some(parseEnum[CommandEnum](key)) # May want to use toLowerAscii, though parseEnum should equal it
+    except:
+      none(CommandEnum)
 
   var
     p = initOptParser()
@@ -161,10 +142,11 @@ proc getCommandLine*(): CommandLineArguments =
     of cmdArgument:
       if i == 0:
         let command = getCommand(key)
-        var exp: ref Exception
-        new(exp)
-        exp.msg = "Invalid command format."
-        if isNone(command): raise exp
+        if isNone(command):
+          var exp: ref Exception
+          new(exp)
+          exp.msg = "Invalid command format."
+          raise exp
         result = CommandLineArguments(command: get(command))
       else:
         case result.command

--- a/src/libvfio/types/environment.nim
+++ b/src/libvfio/types/environment.nim
@@ -2,7 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Environment specific values.
 #
-import options
+import std/options
 
 type
   ArcContainer* = object  ## Container for an Arc Kernel.

--- a/src/libvfio/types/hardware.nim
+++ b/src/libvfio/types/hardware.nim
@@ -2,10 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Hardware configurations for the system.
 #
-import options
-import strformat
-import strutils
-import os
+import std/[options, strformat, strutils, os]
 
 type
   VfioTypes* = enum          ## Enumeration to determine the types of VFIOs.

--- a/src/libvfio/types/locks.nim
+++ b/src/libvfio/types/locks.nim
@@ -2,7 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Lock file for the VMs.
 #
-import json
+import std/json
 import uuids
 
 import config, hardware

--- a/src/libvfio/types/qmp.nim
+++ b/src/libvfio/types/qmp.nim
@@ -2,10 +2,7 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Types and serialization for different QMP commands.
 #
-import sequtils
-import strutils
-import sugar
-import json
+import std/[sequtils, strutils, sugar, json]
 
 type
   QmpCommandEnum* = enum                      ## Enumeration for QMP Commands.

--- a/src/libvfio/utils/getLocks.nim
+++ b/src/libvfio/utils/getLocks.nim
@@ -2,17 +2,23 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: Provide function to get locks
 #
-import os
+import std/os
 
 import ../types
 
 
 type
-  wLock* = object  ## Wrapper for lock so it can contain path
+  WLock* = object  ## Wrapper for lock so it can contain path
     lock*: Lock
     path*: string
 
-proc getLocks*(cfg: Config): seq[wLock] =
+proc initWlock(lock: Lock, path: string): WLock =
+  WLock(
+    lock: lock,
+    path: path
+  )
+
+proc getLocks*(cfg: Config): seq[WLock] =
   ## getLocks - Gets locks
   ## 
   ## Inputs
@@ -25,12 +31,9 @@ proc getLocks*(cfg: Config): seq[wLock] =
   let pattern = cfg.root / "lock" / "*.json"
 
   for filePath in walkPattern(pattern):
-    result &= wLock(
-      lock: getLockFile(filePath),
-      path: filePath
-    )
+    result &= initWlock(getLockFile(filePath), filePath)
 
-proc findLocksByUuid*(cfg: Config, uuid: string): seq[wLock] =
+proc findLocksByUuid*(cfg: Config, uuid: string): seq[WLock] =
   ## findLocksByUuid - Finds locks by matching UUID
   ## 
   ## Inputs
@@ -44,12 +47,9 @@ proc findLocksByUuid*(cfg: Config, uuid: string): seq[wLock] =
   let pattern = cfg.root / "lock" / "*" & uuid & "*.json"
 
   for filePath in walkPattern(pattern):
-    result &= wLock(
-      lock: getLockFile(filePath),
-      path: filePath
-    )
+    result &= initWlock(getLockFile(filePath), filePath)
 
-proc findLocksByPid*(cfg: Config, pid: int): seq[wLock] =
+proc findLocksByPid*(cfg: Config, pid: int): seq[WLock] =
   ## findLocksByPid - Finds locks by matching PID
   ## 
   ## Inputs
@@ -65,7 +65,4 @@ proc findLocksByPid*(cfg: Config, pid: int): seq[wLock] =
   for filePath in walkPattern(pattern):
     let lock = getLockFile(filePath)
     if lock.pidNum == pid:
-      result &= wLock(
-        lock: getLockFile(filePath),
-        path: filePath
-      )
+      result &= initWlock(getLockFile(filePath), filePath)

--- a/src/libvfio/utils/separateVfios.nim
+++ b/src/libvfio/utils/separateVfios.nim
@@ -13,13 +13,9 @@ func separateVfios*(lock: Lock): (seq[Vfio], seq[Vfio]) =
   ## Returns
   ## result - tuple containing two sequences
   ##  ([gpuVfios], [netVfios])
-  var
-    gpus: seq[Vfio]
-    nets: seq[Vfio]
 
   for vfio in lock.vfios:
     if isGpu(vfio):
-      gpus &= vfio
+      result[0] &= vfio
     elif isNet(vfio):
-      nets &= vfio
-  result = (gpus, nets)
+      result[1] &= vfio


### PR DESCRIPTION
No clue the view on the mass changes, but
- Moved all stdlib imports into `std/`s. (Looked like you were grouping them anyway)
- Renamed `wLock` to `WLock`
- Removed the manual case statement in the command parsing, and moved where the exception was initialized.
- Pinned the nimble packages to present versions to reduce build bugs if someone holds an older incompatible package.

These are mostly bikeshed changes, so feel free to tell me to sod off. :stuck_out_tongue: 