### PR TITLE
FIX: added lines to config.nim to fix arcd introspect

### DIFF
--- a/src/libvfio/types/config.nim
+++ b/src/libvfio/types/config.nim
@@ -211,6 +211,8 @@ proc getCommandLine*(): CommandLineArguments =
         of ceStop, ceIntrospect:
           if i == 1:
             result.uuid = key
+          elif i == 2:
+            result.config = some(key)
         of ceLs:
           if i == 1:
             result.option = some(key)


### PR DESCRIPTION
Added option in config.nim to prevent an error when config is passed to the command but not handled properly. New format of the command is `arcd introspect $UUID $configFile`. I've tested and this works fine.