### PR TITLE
Add support for specifying whether exposedPort objects bind to TCP or UDP

### DIFF
--- a/src/libvfio/control/arguments.nim
+++ b/src/libvfio/control/arguments.nim
@@ -335,7 +335,7 @@ func qemuLaunch*(cfg: Config, uuid: string,
   # Port forward for all exposed ports
   if len(cfg.connectivity.exposedPorts) > 0:
     let hostfwds = map(cfg.connectivity.exposedPorts,
-                      (port: Port) => &"hostfwd=tcp::{port.host}-:{port.guest}")
+                      (port: Port) => &"hostfwd={port.protocol}::{port.host}-:{port.guest}")
     result.args &= "-device"
     result.args &= "rtl8139,netdev=net1"
     result.args &= "-netdev"

--- a/src/libvfio/types/connectivity.nim
+++ b/src/libvfio/types/connectivity.nim
@@ -3,9 +3,13 @@
 # Reason: File for connectivity into the system.
 #
 type
-  Port* = object              ## Port to expose to the host from the guest.
+  Port* = object             ## Port to expose to the host from the guest.
     guest*: int              ## Guest port number.
     host*: int               ## Host port number.
+    protocol*: Protocol      ## Protocol of exposed port
 
   Connectivity* = object     ## Connectivity setup.
     exposedPorts*: seq[Port] ## List of exposed ports on the VM.
+
+  Protocol* = enum
+    pTCP = "tcp", pUDP = "udp"

--- a/src/libvfio/types/connectivity.nim
+++ b/src/libvfio/types/connectivity.nim
@@ -2,14 +2,18 @@
 # Copyright: 2666680 Ontario Inc.
 # Reason: File for connectivity into the system.
 #
+import yaml
+
 type
+  Protocol* = enum
+    pTCP = "tcp", pUDP = "udp"
+
   Port* = object             ## Port to expose to the host from the guest.
     guest*: int              ## Guest port number.
     host*: int               ## Host port number.
-    protocol*: Protocol      ## Protocol of exposed port
+    protocol* {.defaultVal: Protocol.pTCP.}: Protocol
+                             ## Protocol of exposed port
 
   Connectivity* = object     ## Connectivity setup.
     exposedPorts*: seq[Port] ## List of exposed ports on the VM.
 
-  Protocol* = enum
-    pTCP = "tcp", pUDP = "udp"


### PR DESCRIPTION
This adds a new field `protocol` within `exposedPorts` to allow for UDP forwards without having to specify raw QEMU arguments.

Ideally, I would have made the new field optional, defaulting to TCP (to make a non-breaking change), but whenever I tried to add a `defaultVal` stanza (per the NimYAML documentation), it would just error.