### PR TITLE
Experimental Live Migration Support

### DIFF
--- a/src/libvfio/control/arguments.nim
+++ b/src/libvfio/control/arguments.nim
@@ -209,7 +209,7 @@ func mdevArgs*(device: Mdev): seq[string] =
   const mdevBase = "/sys/bus/mdev/devices"
   result &= "-device"
   result &=
-        &"vfio-pci,id={device.devId},sysfsdev={mdevBase}/{device.uuid},display=off"
+        &"vfio-pci,id={device.devId},sysfsdev={mdevBase}/{device.uuid},display=off,x-enable-migration=on"
 
 func additionalArgs*(args: QemuArgs): seq[string] =
   ## additionalArgs - Qemu arguments for additional commands.


### PR DESCRIPTION
Dear LibVF.IO Devs,
This pull request aim is to support savevm and loadvm capability for Nvidia Series vGPU.
by default Live Migration is disabled for VFIO devices but Qemu has an experimental flag to enable this feature.
however Nvidia driver also have to be compiled with some flags which will be implemented in @erin-allison aur package.

References:
https://github.com/mbilker/vgpu_unlock-rs/issues/15
