### PR TITLE
Improvements to the generate debug script

### DIFF
--- a/scripts/generate-debug-info.sh
+++ b/scripts/generate-debug-info.sh
@@ -1,92 +1,94 @@
 #!/bin/bash
 
 logFile=./logs/debug.log
+exec &>> ./$logFile
 
 # Make the log directory if it doesn't exist.
 mkdir -p ./logs/
+truncate -s 0 $logFile  # clean it up if already run
 
 # Logging /usr/bin/ binaries
-echo "# /usr/bin/ BINARIES START" >> $logFile
-ls /usr/bin/ >> $logFile
-echo "# /usr/bin/ BINARIES END" >> $logFile
+echo "# /usr/bin/ BINARIES START"
+ls /usr/bin/
+echo "# /usr/bin/ BINARIES END"
 
 # Logging ~/.local/nimble/bin/ binaries
-echo "nimble BINARIES START" >> $logFile
+echo "nimble BINARIES START"
 DIR=`which nimble | xargs dirname`
-echo "Directory: $DIR" >> $logFile
-ls $DIR >> $logFile
-echo "nimble BINARIES END" >> $logFile
+echo "Directory: $DIR"
+ls $DIR
+echo "nimble BINARIES END"
 
 # Logging ~/.local/libvf.io/
-echo "# ~/.local/libvf.io/ START" >> $logFile
-ls ~/.local/libvf.io/ >> $logFile
-echo "# ~/.local/libvf.io/ END" >> $logFile
+echo "# ~/.local/libvf.io/ START"
+ls ~/.local/libvf.io/
+echo "# ~/.local/libvf.io/ END"
 
 # Logging ~/.config/arc/
-echo "# ~/.config/arc/ START" >> $logFile
-ls ~/.config/arc/ >> $logFile
-echo "# ~/.config/arc/ END" >> $logFile
+echo "# ~/.config/arc/ START"
+ls ~/.config/arc/
+echo "# ~/.config/arc/ END"
 
 # Logging IOMMU Groups
-echo "# IOMMU GROUPS START" >> $logFile
+echo "# IOMMU GROUPS START"
 for d in /sys/kernel/iommu_groups/*/devices/*; do
   n=${d#*/iommu_groups/*}; n=${n%%/*}
   printf 'IOMMU Group %s ' "$n"
   lspci -nns "${d##*/}"
-done >> $logFile
-echo "# IOMMU GROUPS END" >> $logFile
+done
+echo "# IOMMU GROUPS END"
 
 # Logging gvm-post.service status
-echo "# GVM-user gvm-post.service START" >> $logFile
-systemctl status gvm-post.service >> $logFile
-echo "# GVM-user gvm-post.service END" >> $logFile
+echo "# GVM-user gvm-post.service START"
+systemctl status gvm-post.service
+echo "# GVM-user gvm-post.service END"
 
 # Logging GVM-user types
-echo "# GVM-user GENERATE VGPU TYPES START" >> $logFile
-cat /etc/gvm/user/generate-vgpu-types.toml >> $logFile
-echo "# GVM-user GENERATE VGPU TYPES END" >> $logFile
+echo "# GVM-user GENERATE VGPU TYPES START"
+cat /etc/gvm/user/generate-vgpu-types.toml
+echo "# GVM-user GENERATE VGPU TYPES END"
 
 # Logging mdevctl types
-echo "# MDEVCTL TYPES START" >> $logFile
-mdevctl types >> $logFile
-echo "# MDEVCTL TYPES END" >> $logFile
+echo "# MDEVCTL TYPES START"
+sudo mdevctl types
+echo "# MDEVCTL TYPES END"
 
 # Logging GVM unit test 'test-device'
-echo "# GVM-user TEST-DEVICE START" >> $logFile
-sudo test-device >> $logFile
-echo "# GVM-user TEST-DEVICE END" >> $logFile 
+echo "# GVM-user TEST-DEVICE START"
+sudo test-device
+echo "# GVM-user TEST-DEVICE END"
 
 # Logging GVM unit test 'test-nvidia-api'
-echo "# GVM-user TEST-NVIDIA-API START" >> $logFile 
-sudo test-nvidia-api >> $logFile
-echo "# GVM-user TEST-NVIDIA-API END" >> $logFile 
+echo "# GVM-user TEST-NVIDIA-API START"
+sudo test-nvidia-api
+echo "# GVM-user TEST-NVIDIA-API END"
 
 # Logging GVM unit test 'test-nvidia-manager'
-echo "# GVM-user TEST-NVIDIA-MANAGER START" >> $logFile 
-sudo test-nvidia-manager >> $logFile
-echo "# GVM-user TEST-NVIDIA-MANAGER END" >> $logFile 
+echo "# GVM-user TEST-NVIDIA-MANAGER START"
+sudo test-nvidia-manager
+echo "# GVM-user TEST-NVIDIA-MANAGER END"
 
 # Logging uname -a
-echo "# UNAME START" >> $logFile
-uname -a >> $logFile
-echo "# UNAME END" >> $logFile
+echo "# UNAME START"
+uname -a
+echo "# UNAME END"
 
 # Logging CPU info
-echo "# CPUINFO START" >> $logFile
-cat /proc/cpuinfo >> $logFile
-echo "# CPUINFO END" >> $logFile
+echo "# CPUINFO START"
+cat /proc/cpuinfo
+echo "# CPUINFO END"
 
 # Logging GRUB config
-echo "# GRUB START" >> $logFile
-cat /etc/default/grub >> $logFile 
-echo "# GRUB END" >> $logFile
+echo "# GRUB START"
+cat /etc/default/grub
+echo "# GRUB END"
 
 # Logging lspci -vvvn
-echo "# LSPCI START" >> $logFile
-sudo lspci -vvvn >> $logFile
-echo "# LSPCI END" >> $logFile
+echo "# LSPCI START"
+sudo lspci -vvvn
+echo "# LSPCI END"
 
 # Logging lsmod
-echo "# LSMOD START" >> $logFile
-lsmod >> $logFile
-echo "# LSMOD END" >> $logFile
+echo "# LSMOD START"
+lsmod
+echo "# LSMOD END"

--- a/scripts/generate-debug-info.sh
+++ b/scripts/generate-debug-info.sh
@@ -11,9 +11,11 @@ ls /usr/bin/ >> $logFile
 echo "# /usr/bin/ BINARIES END" >> $logFile
 
 # Logging ~/.local/nimble/bin/ binaries
-echo "# ~/.local/nimble/bin/ BINARIES START" >> $logFile
-ls ~/.local/nimble/bin/ >> $logFile
-echo "# ~/.local/nimble/bin/ BINARIES END" >> $logFile
+echo "nimble BINARIES START" >> $logFile
+DIR=`which nimble | xargs dirname`
+echo "Directory: $DIR" >> $logFile
+ls $DIR >> $logFile
+echo "nimble BINARIES END" >> $logFile
 
 # Logging ~/.local/libvf.io/
 echo "# ~/.local/libvf.io/ START" >> $logFile


### PR DESCRIPTION
Does the following:
- Adapt to current nimble installation path
- Also redirect stderr to the logfile
- run mdevcrl in sudo
- Truncate the file if re-run